### PR TITLE
Add --list opton for the target command

### DIFF
--- a/kubos/target.py
+++ b/kubos/target.py
@@ -33,7 +33,7 @@ def execCommand(args, following_args):
     target = args['set_target'] #Confusingly the set_target key is the target the user wants to set, no the currently set target
     default_target = args['target'] #this is either the currently set target or the default stm32f4 discovery target
     if args['list']:
-        pint_target_list()
+        print_target_list()
     elif target != None:
         set_target(target)
     else:
@@ -71,7 +71,7 @@ def set_target(new_target):
             print_target_list()
             sys.exit(1)
 
-def pint_target_list():
+def print_target_list():
     target_list = get_target_list()
     print 'Available targets are:\n'
     for _target in target_list:

--- a/kubos/target.py
+++ b/kubos/target.py
@@ -26,13 +26,15 @@ from yotta.options import parser
 
 def addOptions(parser):
     parser.add_argument('set_target', nargs='?', default=None, help='set a new target board or display the current target')
-
+    parser.add_argument('-l', '--list', action='store_true', default=False, help='List all of the available target names')
 
 def execCommand(args, following_args):
     args = vars(args)
     target = args['set_target'] #Confusingly the set_target key is the target the user wants to set, no the currently set target
     default_target = args['target'] #this is either the currently set target or the default stm32f4 discovery target
-    if target != None:
+    if args['list']:
+        pint_target_list()
+    elif target != None:
         set_target(target)
     else:
         show_target(default_target)
@@ -65,11 +67,15 @@ def set_target(new_target):
         print '\nTarget Successfully Set to: %s' % new_target
     else:
         if new_target != '':
-            print >>sys.stderr, 'Error: Requested target %s not available.' % new_target
-        print 'Available targets are:\n'
-        for _target in available_target_list:
-            print >>sys.stderr, _target
-        sys.exit(1)
+            print 'Error: Requested target %s not available.' % new_target
+            print_target_list()
+            sys.exit(1)
+
+def pint_target_list():
+    target_list = get_target_list()
+    print 'Available targets are:\n'
+    for _target in target_list:
+        print _target
 
 
 def get_target_list():


### PR DESCRIPTION
After switching to proxying commands to yotta - the target option gets used in many commands. If no target has been set it will default to the `stm32f407-disco-gcc` target. Just like how yotta will default to the `x86-native-<platform>` target by default.

This behavior allows us to use many of the default yotta commands but it also has a side effect of not allowing `kubos target` to list the targets if no target is set (it will just print the stm32f4 discovery target as that's the default). 

This adds a `--list` option to target so at any time, no matter if you have a target set you can always list and look at all of the available targets with `kubos target --list`.
