### PR TITLE
Check kubos src dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Kubos SDK
+# Kubos CLI
 
 ## NOTE: This module is primarily meant to run inside of a provisioned Vagrant Box.
-## ALMOST ALL USERS WILL WANT TO USE THIS IN THE VAGRANT CONTEXT SEE <LINK> FOR THE VAGRANT INSTALLATION DOCS
+## ALMOST ALL USERS WILL WANT TO USE THIS IN THE VAGRANT CONTEXT SEE [THE KUBOS DOCS](http://docs.kubos.co) FOR THE VAGRANT INSTALLATION DOCS
 
 #### Advanced users may want to use this natively on their machines. Below are the instructions for manual installation
 
 ### Installation:
 
-Install the kubos cli
+Install the kubos-cli
 
 ```
 $ pip install kubos-cli

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Fetch all of the kubos source releases, without activating any of them:
 $ sudo kubos update
 ```
 
-Display a list of all the available release versions `kubos versions` - Note: The versions available to you may different than the following example
+Display a list of all the available release versions `kubos versions` - Note: The versions available to you may be different than the following example
 ```
 $ kubos versions
 
-Availalbe versions are:
+Available versions are:
 v0.0.0
 v0.0.1
 v0.0.2
@@ -45,7 +45,7 @@ Display the active versions of the kubos-cli and kubos source at anytime with `k
 ```
 kubos version
 
-Kubos-CLI version    : 0.1.2
+Kubos-CLI version    : v0.1.2
 Kubos Source version : v0.0.0
 ```
 

--- a/kubos/sdk_config.py
+++ b/kubos/sdk_config.py
@@ -45,10 +45,10 @@ class KubosSDKConfig(object):
         self.appdirs = AppDirs('kubos')
         self.config_path = os.path.join(self.appdirs.user_config_dir, 'kubos-cli.json')
         self.sdk_version = load_sdk_version()
-        self.sdk_edition = load_sdk_edition()
+        #self.sdk_edition = load_sdk_edition()
         self.load_config()
-        thread = threading.Thread(target=self.ping)
-        thread.start()
+        #thread = threading.Thread(target=self.ping)
+        #thread.start()
 
     def load_config(self):
         self.config = {}

--- a/kubos/version.py
+++ b/kubos/version.py
@@ -30,7 +30,7 @@ def addOptions(parser):
 
 def execCommand(args, following_args):
     kubos_version = get_active_kubos_version()
-    print 'Kubos-CLI version    : %s' % get_installed_version('kubos-cli')
+    print 'Kubos-CLI version    : %s' % 'v' + get_installed_version('kubos-cli')
     print 'Kubos Source version : %s' % kubos_version
     if not kubos_version:
         if os.path.isdir(KUBOS_SRC_DIR):

--- a/kubos/version.py
+++ b/kubos/version.py
@@ -33,11 +33,14 @@ def execCommand(args, following_args):
     print 'Kubos-CLI version    : %s' % get_installed_version('kubos-cli')
     print 'Kubos Source version : %s' % kubos_version
     if not kubos_version:
-        repo, origin = get_repo(KUBOS_SRC_DIR)
-        version_list = get_tag_list(repo)
-        print '\nThere\'s not an active Kubos source version..'
-        print 'The available versions are:'
-        print_tag_list(version_list)
-        print 'Please run kubos update <version> (with one of the above versions)' + \
-              'to checkout a version of the source before working with a project.'
-
+        if os.path.isdir(KUBOS_SRC_DIR):
+            repo, origin = get_repo(KUBOS_SRC_DIR)
+            version_list = get_tag_list(repo)
+            print '\nThere\'s not an active Kubos source version..'
+            print 'The available versions are:'
+            print_tag_list(version_list)
+            print 'Please run kubos update <version> (with one of the above versions)' + \
+                  'to checkout a version of the source before working with a project.'
+        else:
+            print 'There are not any local versions of the kubos source currently.'
+            print 'Please run `sudo kubos update` to pull the kubos source before running `kubos version` again'

--- a/kubos/versions.py
+++ b/kubos/versions.py
@@ -27,10 +27,13 @@ def addOptions(parser):
 
 
 def execCommand(args, following_args):
+    if not os.path.isdir(KUBOS_SRC_DIR):
+        print 'No versions are locally available. Please run `sudo kubos update` to pull all of the available source versions.'
+        sys.exit(1)
     repo, origin = get_repo(KUBOS_SRC_DIR)
     tag_list = get_tag_list(repo)
     latest   = get_latest_tag(tag_list)
-    print 'Availalbe versions are:'
+    print 'Available versions are:'
     print_tag_list(tag_list)
     print 'The most recent release is: %s' % latest
 

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "kubos-cli",
-  "version": "0.1.4",
+  "version": "0.0.1",
   "edition": "preview",
   "description": "Kubos SDK",
   "author": "Kubos",

--- a/setup.json
+++ b/setup.json
@@ -5,6 +5,7 @@
         "cryptography",
         "jwt",
         "gitpython",
+        "ndg-httpsclient",
         "packaging",
         "pager",
         "requests",

--- a/setup.json
+++ b/setup.json
@@ -1,10 +1,15 @@
 {
     "install_requires": [
-        "yotta",
-        "setuptools",
-        "requests==2.10.0",
+        "appdirs",
+        "argcomplete",
+        "cryptography",
+        "jwt",
+        "gitpython",
+        "packaging",
         "pager",
-        "appdirs"
+        "requests",
+        "setuptools",
+        "yotta"
     ],
     "classifiers": [
         "Programming Language :: Python :: 2.7"


### PR DESCRIPTION
This should be the last PR before the first kubos-cli version ships.

This PR adds:
* Error checking for cases where ~/.kubos doesn't exist
* A semi-accurate and updated README to the kubos-cli repo.
* The accurate list of kubos-cli install dependencies