### PR TITLE
Enable modules to force link their entire static lib

### DIFF
--- a/kubos/override/reimplemented_modules/cmakegen.py
+++ b/kubos/override/reimplemented_modules/cmakegen.py
@@ -1,0 +1,48 @@
+# Kubos SDK
+# Copyright (C) 2017 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from yotta.lib.cmakegen import *
+
+class KubosCMakeGen(CMakeGen):
+    def _kCheckImmediateDeps(self, deps):
+        # make a copy so we don't recurse
+        new_deps = {}
+        dep_items = [i for i in deps.items()]
+        for name, component in dep_items:
+            if component.isTestDependency(): continue
+            if component.getLinkWholeArchive():
+                # surround 'whole archive' libs with the proper linker args
+                new_key = ('${YOTTA_LINK_WHOLE_ARCHIVE_PRE} ' \
+                           '%s ${YOTTA_LINK_WHOLE_ARCHIVE_POST}') % name
+                new_deps[new_key] = deps[name]
+            else:
+                new_deps[name] = deps[name]
+
+        return new_deps
+
+    def generateSubDirList(self, builddir, dirname, source_files, component,
+                           all_subdirs, immediate_dependencies, object_name,
+                           resource_subdirs, is_executable):
+
+        deps = self._kCheckImmediateDeps(immediate_dependencies)
+        return super(KubosCMakeGen, self).generateSubDirList(builddir, dirname,
+                                                             source_files,
+                                                             component,
+                                                             all_subdirs,
+                                                             deps, object_name,
+                                                             resource_subdirs,
+                                                             is_executable)
+
+CMakeGen = KubosCMakeGen

--- a/kubos/override/reimplemented_modules/component.py
+++ b/kubos/override/reimplemented_modules/component.py
@@ -1,0 +1,22 @@
+# Kubos SDK
+# Copyright (C) 2017 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from yotta.lib.component import *
+
+class KubosComponent(Component):
+    def getLinkWholeArchive(self):
+        return self.description.get('linkWholeArchive', False)
+
+Component = KubosComponent

--- a/kubos/override/yotta_lib.py
+++ b/kubos/override/yotta_lib.py
@@ -21,8 +21,10 @@ convenient to use in the Kubos-cli.
 '''
 
 import yotta.lib.access
-from reimplemented_modules import access, detect
+from reimplemented_modules import access, cmakegen, component, detect
 
 def exec_override():
     yotta.lib.access = access
     yotta.lib.detect = detect
+    yotta.lib.cmakegen = cmakegen
+    yotta.lib.component = component


### PR DESCRIPTION
This enables Kubos modules to surround their static lib with `-Wl,--whole-archive` and `-Wl,--no-whole-archive`, forcing the linker to keep all symbols in the static lib (needed for the additional CSP slash commands)

I tried to keep the amount of copy-pasted code to a minimum, so I first subclass and then replace the super class in override module. LMK if this works..

This pull request needs to be merged for kubostech/kubos#34

/cc @kubostech/devs 