### PR TITLE
[KUBOS-330] Adding 'kubos init' for linux option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ $ kubos init  <project name>
 ```
 
 
+By default, this will create a new KubOS project with example code to run on KubOS RT.  If you
+would like to create a project with example code to run on KubOS Linux, add the '--linux' 
+(or '-l') option.
+
+
+```
+$ kubos init --linux <project name>
+```
+
+
 #### Setting a Target Board
 Kubos Projects automatically set and use predefined build, flash and debug configurations based on the hardware platform you are working on.
 

--- a/kubos/init.py
+++ b/kubos/init.py
@@ -20,7 +20,7 @@ import os
 import shutil
 import sys
 
-from kubos.utils.git_common import KUBOS_EXAMPLE_DIR
+from kubos.utils.git_common import KUBOS_RT_EXAMPLE_DIR
 from kubos.utils.git_common import KUBOS_LINUX_EXAMPLE_DIR
 from yotta import link, link_target
 from yotta.lib import folders
@@ -45,7 +45,7 @@ def execCommand(args, following_args):
     if args.linux is True:
         shutil.copytree(KUBOS_LINUX_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
     else:
-        shutil.copytree(KUBOS_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
+        shutil.copytree(KUBOS_RT_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
         
     #change project name in module.json
     module_json = os.path.join(proj_name_dir, 'module.json')

--- a/kubos/init.py
+++ b/kubos/init.py
@@ -21,13 +21,16 @@ import shutil
 import sys
 
 from kubos.utils.git_common import KUBOS_EXAMPLE_DIR
+from kubos.utils.git_common import KUBOS_LINUX_EXAMPLE_DIR
 from yotta import link, link_target
 from yotta.lib import folders
 from yotta.lib.detect import systemDefaultTarget
 
 def addOptions(parser):
     parser.add_argument('proj_name', nargs=1, help='specify the project name')
-
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-l', '--linux', action='store_true', help='Initialize Kubos SDK project for KubOS Linux'
+    group.add_argument('-r', '--rt', action='store_true', default=True, help='Initialize Kubos SDK project for KubOS RT'
 
 def execCommand(args, following_args):
     proj_name = vars(args)['proj_name'][0] #vars returns a dict of args. proj_name is a list since nargs=1
@@ -38,7 +41,12 @@ def execCommand(args, following_args):
         print >>sys.stderr, 'The project directory %s already exists. Not overwritting the current directory' % proj_name_dir
         sys.exit(1)
 
-    shutil.copytree(KUBOS_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
+    #Set the correct example directory based on the desired OS
+    if args['linux']:
+        shutil.copytree(KUBOS_LINUX_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
+    else:
+        shutil.copytree(KUBOS_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
+        
     #change project name in module.json
     module_json = os.path.join(proj_name_dir, 'module.json')
     with open(module_json, 'r') as init_module_json:

--- a/kubos/init.py
+++ b/kubos/init.py
@@ -29,8 +29,8 @@ from yotta.lib.detect import systemDefaultTarget
 def addOptions(parser):
     parser.add_argument('proj_name', nargs=1, help='specify the project name')
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('-l', '--linux', action='store_true', help='Initialize Kubos SDK project for KubOS Linux'
-    group.add_argument('-r', '--rt', action='store_true', default=True, help='Initialize Kubos SDK project for KubOS RT'
+    group.add_argument('-l', '--linux', action='store_true', help='Initialize Kubos SDK project for KubOS Linux')
+    group.add_argument('-r', '--rt', action='store_true', default=True, help='Initialize Kubos SDK project for KubOS RT')
 
 def execCommand(args, following_args):
     proj_name = vars(args)['proj_name'][0] #vars returns a dict of args. proj_name is a list since nargs=1
@@ -42,7 +42,7 @@ def execCommand(args, following_args):
         sys.exit(1)
 
     #Set the correct example directory based on the desired OS
-    if args['linux']:
+    if args.linux is True:
         shutil.copytree(KUBOS_LINUX_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
     else:
         shutil.copytree(KUBOS_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))

--- a/kubos/init.py
+++ b/kubos/init.py
@@ -41,11 +41,9 @@ def execCommand(args, following_args):
         print >>sys.stderr, 'The project directory %s already exists. Not overwritting the current directory' % proj_name_dir
         sys.exit(1)
 
-    #Set the correct example directory based on the desired OS
-    if args.linux is True:
-        shutil.copytree(KUBOS_LINUX_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
-    else:
-        shutil.copytree(KUBOS_RT_EXAMPLE_DIR, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
+    #Copy in the correct example directory based on the desired OS
+    example_dir = KUBOS_LINUX_EXAMPLE_DIR if args.linux else KUBOS_RT_EXAMPLE_DIR
+    shutil.copytree(example_dir, proj_name_dir, ignore=shutil.ignore_patterns('.git'))
         
     #change project name in module.json
     module_json = os.path.join(proj_name_dir, 'module.json')

--- a/kubos/update.py
+++ b/kubos/update.py
@@ -42,6 +42,7 @@ def execCommand(args, following_args):
     os.chdir(KUBOS_DIR)
     src_repo = clone_repo(KUBOS_SRC_DIR, KUBOS_SRC_URL)
     clone_example_repo(KUBOS_EXAMPLE_DIR, KUBOS_EXAMPLE_URL)
+    clone_example_repo(KUBOS_LINUX_EXAMPLE_DIR, KUBOS_LINUX_EXAMPLE_URL)
     set_version = vars(args)['set_version']
     if set_version:
         check_provided_version(set_version, src_repo)
@@ -49,9 +50,9 @@ def execCommand(args, following_args):
 
 def clone_example_repo(repo_dir, repo_url):
     '''
-    For the example repo (kubos-rt-example) we simply checkout
-    the latest version, rather than making the user specify a 
-    specific version of the example repo.
+    For the example repos (kubos-rt-example, kubos-linux-example) we 
+    simply checkout the latest version, rather than making the user 
+    specify a specific version of the example repo.
     '''
     repo = clone_repo(repo_dir, repo_url)
     tag_list = versions.get_tag_list(repo)

--- a/kubos/update.py
+++ b/kubos/update.py
@@ -41,7 +41,7 @@ def execCommand(args, following_args):
         os.makedirs(KUBOS_DIR)
     os.chdir(KUBOS_DIR)
     src_repo = clone_repo(KUBOS_SRC_DIR, KUBOS_SRC_URL)
-    clone_example_repo(KUBOS_EXAMPLE_DIR, KUBOS_EXAMPLE_URL)
+    clone_example_repo(KUBOS_RT_EXAMPLE_DIR, KUBOS_RT_EXAMPLE_URL)
     clone_example_repo(KUBOS_LINUX_EXAMPLE_DIR, KUBOS_LINUX_EXAMPLE_URL)
     set_version = vars(args)['set_version']
     if set_version:

--- a/kubos/utils/git_common.py
+++ b/kubos/utils/git_common.py
@@ -23,7 +23,7 @@ HOME_DIR = os.path.expanduser('~')
 KUBOS_DIR = os.path.join(HOME_DIR, '.kubos')
 KUBOS_SRC_DIR = os.path.join(KUBOS_DIR, 'kubos')
 KUBOS_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'rt-example')
-KUBOS_LINUX_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'linux-example'
+KUBOS_LINUX_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'linux-example')
 
 KUBOS_GIT_DIR = os.path.join(KUBOS_SRC_DIR, '.git')
 KUBOS_VERSION_FILE = os.path.join(KUBOS_DIR, 'version.txt')

--- a/kubos/utils/git_common.py
+++ b/kubos/utils/git_common.py
@@ -17,12 +17,12 @@ import git
 import os
 
 KUBOS_SRC_URL = 'https://github.com/kubostech/kubos'
-KUBOS_EXAMPLE_URL = 'https://github.com/kubostech/kubos-rt-example'
+KUBOS_RT_EXAMPLE_URL = 'https://github.com/kubostech/kubos-rt-example'
 KUBOS_LINUX_EXAMPLE_URL = 'https://github.com/kubostech/kubos-linux-example'
 HOME_DIR = os.path.expanduser('~')
 KUBOS_DIR = os.path.join(HOME_DIR, '.kubos')
 KUBOS_SRC_DIR = os.path.join(KUBOS_DIR, 'kubos')
-KUBOS_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'rt-example')
+KUBOS_RT_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'rt-example')
 KUBOS_LINUX_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'linux-example')
 
 KUBOS_GIT_DIR = os.path.join(KUBOS_SRC_DIR, '.git')

--- a/kubos/utils/git_common.py
+++ b/kubos/utils/git_common.py
@@ -18,10 +18,12 @@ import os
 
 KUBOS_SRC_URL = 'https://github.com/kubostech/kubos'
 KUBOS_EXAMPLE_URL = 'https://github.com/kubostech/kubos-rt-example'
+KUBOS_LINUX_EXAMPLE_URL = 'https://github.com/kubostech/kubos-linux-example'
 HOME_DIR = os.path.expanduser('~')
 KUBOS_DIR = os.path.join(HOME_DIR, '.kubos')
 KUBOS_SRC_DIR = os.path.join(KUBOS_DIR, 'kubos')
-KUBOS_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'example')
+KUBOS_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'rt-example')
+KUBOS_LINUX_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'linux-example'
 
 KUBOS_GIT_DIR = os.path.join(KUBOS_SRC_DIR, '.git')
 KUBOS_VERSION_FILE = os.path.join(KUBOS_DIR, 'version.txt')


### PR DESCRIPTION
Added a new parameter to 'kubos init', '--linux' ('-l' for short), which will cause the SDK to copy in the kubos-linux-example project rather than the kubos-rt-example project when initializing a new SDK project.  This example is based on the kubos-csp-example, but updated to run correctly on a linux system.

I also added an '--rt' ('-r') option to balance things out.  Really it doesn't do anything, but from a UX perspective, I think it's nice to give users an option to intentionally specify that they want to create a KubOS RT project instead of a KubOS Linux project.  (It is mutually exclusive with --linux)