### PR TITLE
KUBOS-341 Backfill unit tests

### DIFF
--- a/kubos/main.py
+++ b/kubos/main.py
@@ -179,4 +179,4 @@ def main():
         logging.warning('interrupted')
         status = -1
 
-    sys.exit(status or 0)
+    return status or 0

--- a/kubos/test/test_build.py
+++ b/kubos/test/test_build.py
@@ -1,5 +1,5 @@
 # Kubos CLI
-# Copyright (C) 2016 Kubos Corporation
+# Copyright (C) 2017 Kubos Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubos/test/test_build.py
+++ b/kubos/test/test_build.py
@@ -1,0 +1,47 @@
+# Kubos CLI
+# Copyright (C) 2016 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kubos
+import mock
+import sys
+import unittest
+import yotta.build
+
+from kubos.test.utils import  KubosTestCase
+
+class KubosBuildTest(KubosTestCase):
+    '''
+    Since the kubos build command proxies to the default yotta implementation
+    this test only looks to make sure that the yotta implementation is called.
+    There's a separate yotta unit test to test the build functionality.
+    '''
+    def setUp(self):
+        super(KubosBuildTest, self).setUp()
+        self.test_function = mock.MagicMock()
+        yotta.build.execCommand = self.test_function
+        self.test_command = 'build'
+        sys.argv.append(self.test_command)
+
+
+    def test_build(self):
+        kubos.main()
+        self.assert_default_yotta_call()
+
+
+    def tearDown(self):
+        super(KubosBuildTest, self).tearDown()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kubos/test/test_init.py
+++ b/kubos/test/test_init.py
@@ -1,5 +1,5 @@
 # Kubos CLI
-# Copyright (C) 2016 Kubos Corporation
+# Copyright (C) 2017 Kubos Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubos/test/test_init.py
+++ b/kubos/test/test_init.py
@@ -1,0 +1,57 @@
+# Kubos CLI
+# Copyright (C) 2016 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.import argparse
+
+import argparse
+import kubos
+import os
+import shutil
+import tempfile
+import unittest
+
+from kubos import init
+from kubos.test import utils
+
+class KubosInitTest(utils.KubosTestCase):
+
+    def setUp(self):
+        super(KubosInitTest, self).setUp()
+        self.proj_name = 'test-project'
+        self.args = argparse.Namespace()
+        self.args.proj_name = [self.proj_name] # argparse returns proj_name as an array
+        self.args.linux = False
+
+    def test_creates_proj_dir(self):
+        self.proj_dir = os.path.join(self.base_dir, self.proj_name)
+        main_src_file = os.path.join(self.proj_dir, 'source', 'main.c')
+        kubos.init.execCommand(self.args, None)
+        self.assertTrue(os.path.isdir(self.proj_dir))
+        self.assertTrue(os.path.isfile(main_src_file))
+
+
+    def test_overwrite_existing(self):
+        self.proj_name = 'test-project'
+        self.proj_dir = os.path.join(self.base_dir, self.proj_name)
+        with self.assertRaises(SystemExit):
+            kubos.init.execCommand(self.args, None)
+            #we cd into the project directory to change the module.json file in execCommand
+            os.chdir(self.base_dir)
+            kubos.init.execCommand(self.args, None)
+
+
+    def tearDown(self):
+        super(KubosInitTest, self).tearDown()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kubos/test/test_init.py
+++ b/kubos/test/test_init.py
@@ -16,7 +16,6 @@
 import argparse
 import kubos
 import os
-import shutil
 import tempfile
 import unittest
 

--- a/kubos/test/test_sdk_utils.py
+++ b/kubos/test/test_sdk_utils.py
@@ -1,5 +1,5 @@
 # Kubos CLI
-# Copyright (C) 2016 Kubos Corporation
+# Copyright (C) 2017 Kubos Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubos/test/test_sdk_utils.py
+++ b/kubos/test/test_sdk_utils.py
@@ -1,0 +1,81 @@
+# Kubos CLI
+# Copyright (C) 2016 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import kubos
+import mock
+import os
+import sys
+import unittest
+import yotta.build
+
+from yotta.test.cli.util import  Test_Trivial_Lib #
+from yotta.test.cli.test_target import Test_Module_JSON
+
+
+from kubos.utils import sdk_utils
+from kubos.test.utils import KubosTestCase
+
+class KubosSdkUtilsTest(KubosTestCase):
+
+    def setUp(self):
+        super(KubosSdkUtilsTest, self).setUp()
+        '''
+        Make the following directory structure to test the recursive module/target discovery function
+        .../base_dir
+               |____ dir_a
+               |        |____ module.json
+               |____ dir_b
+                        |____ dir_c
+                                 |____ target.json
+        '''
+        self.dir_a = os.path.join(self.base_dir, 'dir_a')
+        self.dir_b = os.path.join(self.base_dir, 'dir_b')
+        self.dir_c = os.path.join(self.dir_b, 'dir_c')
+        self.module_json = os.path.join(self.dir_a, 'module.json')
+        self.target_json = os.path.join(self.dir_c, 'target.json')
+
+        os.makedirs(self.dir_a)
+        os.makedirs(self.dir_b)
+        os.makedirs(self.dir_c)
+
+        with open(self.module_json, 'w') as module_file:
+            module_file.write(json.dumps(Test_Module_JSON))
+        with open(self.target_json, 'w') as target_file:
+            target_file.write(json.dumps(Test_Module_JSON))
+
+
+    def test_link_entities_discovery(self):
+        sys.argv.append('link')
+        sdk_utils.run_link = mock.MagicMock()
+        sdk_utils.link_entities(self.base_dir, None)
+        self.assertEqual(sdk_utils.run_link.call_count, 2)
+        # import pdb;pdb.set_trace()
+        call_list = sdk_utils.run_link.call_args_list
+        expected_args = [ self.module_json, self.target_json ]
+        idx = 0
+        for call in call_list:
+            args, kwargs = call
+            self.assertEqual(expected_args[idx], args[0])
+            idx = idx + 1
+
+
+    def tearDown(self):
+        super(KubosSdkUtilsTest, self).tearDown()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kubos/test/test_sdk_utils.py
+++ b/kubos/test/test_sdk_utils.py
@@ -66,7 +66,7 @@ class KubosSdkUtilsTest(KubosTestCase):
                           'no_install': False,
                           'target_or_path': json_data['name'],
                           'config': None}
-        sdk_utils.run_link(self.module_json, self.dir_a) #link test target to the test module
+        sdk_utils.run_link(self.module_json, self.dir_a) #Link the module to an arbitrary location
         link.execCommand.assert_called()
         link_target.execCommand.assert_not_called()
         args, kwargs = link.execCommand.call_args[0]
@@ -82,7 +82,7 @@ class KubosSdkUtilsTest(KubosTestCase):
                           'no_install': False,
                           'target_or_path': None,
                           'config': None}
-        sdk_utils.run_link(self.target_json, None) #link test target to the test module
+        sdk_utils.run_link(self.target_json, None) #link test target to the "global cache" of targets
         link.execCommand.assert_not_called()
         link_target.execCommand.assert_called_once()
         args, kwargs = link_target.execCommand.call_args[0]
@@ -98,8 +98,8 @@ class KubosSdkUtilsTest(KubosTestCase):
         expected_args = [ self.module_json, self.target_json ]
         idx = 0
         for call in call_list:
-            args, kwargs = call
-            self.assertEqual(expected_args[idx], args[0])
+            args, kwargs = call[0]
+            self.assertEqual(expected_args[idx], args)
             idx = idx + 1
 
 

--- a/kubos/test/utils.py
+++ b/kubos/test/utils.py
@@ -1,5 +1,5 @@
 # Kubos CLI
-# Copyright (C) 2016 Kubos Corporation
+# Copyright (C) 2017 Kubos Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubos/test/utils.py
+++ b/kubos/test/utils.py
@@ -1,0 +1,66 @@
+# Kubos CLI
+# Copyright (C) 2016 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+
+class KubosTestCase(unittest.TestCase):
+    test_arg = None #Additional command line argument needed by any specific test cases
+
+    def setUp(self):
+        '''
+        To start this clears any extra command line arguments used to start
+        this test. Then create a temporary directory (base_dir) and cd into
+        that directory. Then start the test case.
+        '''
+        first_arg = sys.argv[0]
+        sys.argv = [first_arg]
+        self.start_dir = os.getcwd()
+        self.base_dir = tempfile.mkdtemp()
+        os.chdir(self.base_dir)
+
+
+    def assert_default_yotta_call(self):
+        '''
+        This tests to ensure that the default execCommand from yotta was called
+        for the specific command being tested.
+        '''
+        call_list = self.test_function.call_args.call_list()
+        self.assertTrue(len(call_list) == 1)
+        args, kwargs = call_list[0]
+        arg_dict = vars(args[0])
+        self.assertTrue(arg_dict['subcommand_name'] == self.test_command)
+
+
+    def tearDown(self):
+        '''
+        cd back to the starting directory of the test, then try to remove the
+        temporary created for the test case. Finally try to remove any command
+        line arguments added during the test case
+        '''
+        os.chdir(self.start_dir)
+        shutil.rmtree(self.base_dir)
+        try:
+            sys.argv.remove(self.test_command)
+        except ValueError:
+            pass
+        if self.test_arg in sys.argv: # Not all tests requrire an additional argument
+            sys.argv.remove(self.test_arg)
+

--- a/kubos/test/utils.py
+++ b/kubos/test/utils.py
@@ -23,6 +23,7 @@ import unittest
 
 class KubosTestCase(unittest.TestCase):
     test_arg = None #Additional command line argument needed by any specific test cases
+    test_command = None #Not all test cases define a 'test_command'
 
     def setUp(self):
         '''

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "kubos-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "edition": "preview",
   "description": "Kubos CLI",
   "author": "Kubos",


### PR DESCRIPTION
This is a first pass (of many) for adding unit tests to the kubos-cli.

The test_build.py is a "template" unit test which will be duplicated for each of the commands that proxy directly to yotta implementations of those commands.

This includes test for the `build` and `init` commands as well as some of the internal functions for linking and discovering modules and targets.

cc/ @kubostech/devs 