### PR TITLE
Purge linked modules and targets before linking new modules to the global cache

### DIFF
--- a/kubos/use.py
+++ b/kubos/use.py
@@ -15,7 +15,7 @@
 
 from yotta.options import parser
 
-from kubos.utils import git_utils
+from kubos.utils import git_utils, sdk_utils
 from kubos.utils.constants import  KUBOS_SRC_DIR
 
 def addOptions(parser):
@@ -27,4 +27,5 @@ def execCommand(args, following_args):
     version = args['set_version'][0]
     kubos_repo = git_utils.get_repo(KUBOS_SRC_DIR)
     git_utils.check_provided_version(version, kubos_repo)
-
+    sdk_utils.purge_global_cache()
+    sdk_utils.link_to_global_cache(KUBOS_SRC_DIR)

--- a/kubos/utils/sdk_utils.py
+++ b/kubos/utils/sdk_utils.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import logging
 import os
+import shutil
 import yotta
 import yotta.link
 import yotta.link_target
@@ -103,6 +104,11 @@ def run_link(src, dst):
                                    no_install=False)
     link_module.execCommand(link_args, '')
     os.chdir(start_dir)
+
+
+def purge_global_cache():
+    shutil.rmtree(GLOBAL_MODULE_PATH)
+    shutil.rmtree(GLOBAL_TARGET_PATH)
 
 
 def link_global_cache_to_project(project):

--- a/kubos/version.py
+++ b/kubos/version.py
@@ -22,6 +22,7 @@ from pip.utils import get_installed_version
 from yotta.options import parser
 
 from kubos.utils import git_utils
+from kubos.utils.constants import KUBOS_SRC_DIR
 
 def addOptions(parser):
     parser.add_argument('-l', '--list', action='store_true', default=False, help='List all of the locally available KubOS source versions')

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "kubos-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "edition": "preview",
   "description": "Kubos CLI",
   "author": "Kubos",


### PR DESCRIPTION
This PR changes the `use` command to delete the globally linked modules and targets from `~/.kubos/kubos/.... before checking out and relinking a different version of the kubos source tree.

This is needed because different versions may add or more importantly remove old modules/targets. When targets are removed from the kubos source the symlinks remain in `/usr/local/yotta_...`. These "out of date" symlinks cause errors when we try to link those out of date modules/targets into projects.

The simplest way to get rid of these symlinks is to just delete the `/usr/local/lib/yotta_modules` and `/usr/local/lib/yotta_targets` directories before we link new modules and targets into those directories.

This PR also includes:
* A version bump to match what is currently uploaded in pypi
* Missing import in version.py

cc/ @kubostech/devs