### PR TITLE
KUBOS-361 Add option to the use command to checkout specific branches or tags.

### DIFF
--- a/kubos/update.py
+++ b/kubos/update.py
@@ -43,5 +43,5 @@ def execCommand(args, following_args):
     status_spinner.stop_spinner(spinner)
     set_version = vars(args)['set_version']
     if set_version:
-        check_provided_version(set_version, src_repo)
+        git_utils.check_provided_version(set_version, src_repo)
 

--- a/kubos/use.py
+++ b/kubos/use.py
@@ -19,13 +19,18 @@ from kubos.utils import git_utils, sdk_utils
 from kubos.utils.constants import  KUBOS_SRC_DIR
 
 def addOptions(parser):
-    parser.add_argument('set_version', nargs=1, help='Set a specific version of the KubOS modules to build your projects against.')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--branch', nargs='?', help='Set the branch flag to specify to checkout a branch, not a tag')
+    group.add_argument('set_version', nargs='?', default=None, help='Set a specific version of the KubOS modules to build your projects against.')
 
 
 def execCommand(args, following_args):
-    args = vars(args)
-    version = args['set_version'][0]
+    version = args.set_version
+    branch  = args.branch
     kubos_repo = git_utils.get_repo(KUBOS_SRC_DIR)
-    git_utils.check_provided_version(version, kubos_repo)
+    if branch:
+        git_utils.checkout_branch_update_version(branch, kubos_repo)
+    elif version:
+        git_utils.check_provided_version(version, kubos_repo)
     sdk_utils.purge_global_cache()
     sdk_utils.link_to_global_cache(KUBOS_SRC_DIR)

--- a/kubos/use.py
+++ b/kubos/use.py
@@ -19,9 +19,11 @@ from kubos.utils import git_utils, sdk_utils
 from kubos.utils.constants import  KUBOS_SRC_DIR
 
 def addOptions(parser):
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument('--branch', nargs='?', help='Set the branch flag to specify to checkout a branch, not a tag')
-    group.add_argument('set_version', nargs='?', default=None, help='Set a specific version of the KubOS modules to build your projects against.')
+    group = parser.add_mutually_exclusive_group(required=True)
+    #Nargs has to be optional for the mutually exclusive arguments - but the required=True
+    #specifies that at least one of them has to be provided or argparse will thrown an error
+    group.add_argument('-b', '--branch', nargs='?', default=None, help='Set the branch flag to specify to checkout a branch, not a tag')
+    group.add_argument('set_version',    nargs='?', default=None, help='Set a specific version of the KubOS modules to build your projects against.')
 
 
 def execCommand(args, following_args):
@@ -29,7 +31,7 @@ def execCommand(args, following_args):
     branch  = args.branch
     kubos_repo = git_utils.get_repo(KUBOS_SRC_DIR)
     if branch:
-        git_utils.checkout_branch_update_version(branch, kubos_repo)
+        git_utils.checkout_and_update_version(branch, kubos_repo)
     elif version:
         git_utils.check_provided_version(version, kubos_repo)
     sdk_utils.purge_global_cache()

--- a/kubos/utils/git_utils.py
+++ b/kubos/utils/git_utils.py
@@ -67,7 +67,7 @@ def checkout_branch_update_version(branch, repo):
             update_version_file(branch)
     except:
         logging.error('There was an error checking out branch "%s"' % branch)
-        logging.error('The error details are: %s' %  sys.exc_info()[0])
+        logging.debug('The error details are: %s' %  sys.exc_info()[0])
 
 
 def checkout_tag_update_version(tag, repo):


### PR DESCRIPTION
This PR adds the ability to checkout either tags or branches with the `use --branch <branch_name>` command.

It also modifies the `update` command to fetch branches and tags, rather than tags only.

cc/ @kubostech/devs 