### PR TITLE
fixing JWT version number and adding pysocks dependency for the vagrant environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+jwt==0.3.2
 ndg-httpsclient
 packaging
+pysocks


### PR DESCRIPTION
JWT v0.3.2 was the last version to support python 2.7. Freezing on this version should not affect any functionality since yotta development has stopped.