### PR TITLE
Fixing jwt dependency version number, bumping version number

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "kubos-cli",
-  "version": "0.0.2",
+  "version": "0.2.1",
   "edition": "preview",
   "description": "Kubos CLI",
   "author": "Kubos",

--- a/setup.json
+++ b/setup.json
@@ -3,7 +3,7 @@
         "appdirs",
         "argcomplete",
         "cryptography",
-        "jwt",
+        "jwt==0.3.2",
         "gitpython",
         "ndg-httpsclient",
         "packaging",


### PR DESCRIPTION
Master is protected so this has to go through a PR. These are the live production changes made Friday.