### PR TITLE
Bumping version to 0.2.2

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "kubos-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "edition": "preview",
   "description": "Kubos CLI",
   "author": "Kubos",


### PR DESCRIPTION
For CI purposes we need to release a new build of the kubos-cli.

The only change for this version is returning accurate return codes from commands (which is critical for CI to work properly)