### PR TITLE
KUBOS-412 Updating Regex for tag detection to prevent printing branch stability warning for tags.

### DIFF
--- a/kubos/utils/git_utils.py
+++ b/kubos/utils/git_utils.py
@@ -60,7 +60,7 @@ def fetch_tags(repo):
 
 
 def checkout_and_update_version(ref, repo):
-    tag_expr = re.compile('v+\d\.+\d\.+\d\.*') #Tags follow the vX.X.X convention
+    tag_expr = re.compile('v?\d+\.\d+\.\d+\.*') #Tags follow the v?X.X.X convention
     is_tag = tag_expr.match(ref)
     logging.info("Checking out '%s'" % ref)
     if not is_tag:


### PR DESCRIPTION
Our tags used the vX.X.X convention initially but has dropped the 'v' and changed to X.X.X

The regex used to detect the difference in a tag and version didn't account for the change. This caused a warning message about branch stability to be printed when checking out valid and stable tags.

 Another bug (That would fail for tags containing more than one digit per field (major, minor patch)) was discovered and fixed now in this PR.