### PR TITLE
KUBOS-438 Filter Minor tags/releases

### DIFF
--- a/kubos/utils/constants.py
+++ b/kubos/utils/constants.py
@@ -34,4 +34,4 @@ SDK_MODULE_JSON = os.path.join(KUBOS_RESOURCE_DIR, 'module.json')
 GLOBAL_TARGET_PATH  = os.path.join('/', 'usr', 'local', 'lib', 'yotta_targets')
 GLOBAL_MODULE_PATH  = os.path.join('/', 'usr', 'local', 'lib', 'yotta_modules')
 
-SHOW_NUMBER_MINOR_VERSIONS = 0
+SHOW_NUMBER_CD_VERSIONS = 0

--- a/kubos/utils/constants.py
+++ b/kubos/utils/constants.py
@@ -34,3 +34,4 @@ SDK_MODULE_JSON = os.path.join(KUBOS_RESOURCE_DIR, 'module.json')
 GLOBAL_TARGET_PATH  = os.path.join('/', 'usr', 'local', 'lib', 'yotta_targets')
 GLOBAL_MODULE_PATH  = os.path.join('/', 'usr', 'local', 'lib', 'yotta_modules')
 
+SHOW_NUMBER_MINOR_VERSIONS = 3

--- a/kubos/utils/constants.py
+++ b/kubos/utils/constants.py
@@ -34,4 +34,4 @@ SDK_MODULE_JSON = os.path.join(KUBOS_RESOURCE_DIR, 'module.json')
 GLOBAL_TARGET_PATH  = os.path.join('/', 'usr', 'local', 'lib', 'yotta_targets')
 GLOBAL_MODULE_PATH  = os.path.join('/', 'usr', 'local', 'lib', 'yotta_modules')
 
-SHOW_NUMBER_MINOR_VERSIONS = 3
+SHOW_NUMBER_MINOR_VERSIONS = 0

--- a/kubos/utils/git_utils.py
+++ b/kubos/utils/git_utils.py
@@ -110,7 +110,7 @@ def clone_example_repo(repo_dir, repo_url):
     repo = clone_repo(repo_dir, repo_url)
     tag_list   = get_tag_list(repo)
     latest_tag = get_latest_tag(tag_list)
-    checkout_and_update_version(latest_tag.name, repo)
+    checkout_and_update_version(latest_tag, repo)
 
 
 def clone_repo(repo_dir, repo_url):
@@ -142,8 +142,8 @@ def set_active_kubos_version(set_tag, repo):
     tag_list = get_tag_list(repo)
     found = False
     for tag in tag_list:
-        if tag.name == set_tag:
-            checkout_and_update_version(tag.name, repo)
+        if tag == set_tag:
+            checkout_and_update_version(tag, repo)
             found = True
             break
     if not found:

--- a/kubos/utils/git_utils.py
+++ b/kubos/utils/git_utils.py
@@ -63,8 +63,8 @@ def filter_cd_generated_tags(display_num, tag_list):
 def print_tag_list(tag_list, filter=True):
     active_version = get_active_kubos_version()
 
-    if filter:  #filter the minor versions
-        tag_list = filter_cd_generated_tags(SHOW_NUMBER_MINOR_VERSIONS, tag_list)
+    if filter:  #filter the CD Gernerated versions
+        tag_list = filter_cd_generated_tags(SHOW_NUMBER_CD_VERSIONS, tag_list)
 
     for tag in tag_list:
         if tag == active_version:

--- a/kubos/utils/git_utils.py
+++ b/kubos/utils/git_utils.py
@@ -38,20 +38,24 @@ def get_tag_list(repo):
 
 def filter_cd_generated_tags(display_num, tag_list):
     '''
-    With every merge to Master of the Kubos repo theres the CD config generates
-    and releases a new tag/release..
-    This filters only the most recent display_num number of release tags.
+    cd_generated_versions are the auto generated releases from the CD configuration. With
+    every merge to master of the kubos repo one of these release tags is generated.
+
+    ga_release_versions are manually created, more significant (general availability) releases that should have higher levels
+    of stability than cd_generated_version releases will.
+
+    This function filters only the most recent display_num number of cd_generated_versions from tag_list.
     '''
     filtered_tags = []
-    major_version = re.compile('v?\d+\.\d+\.\d+')
-    minor_version = re.compile('v?\d+\.\d+\.\d+\.\d+')
+    ga_release_version   = re.compile('v?\d+\.\d+\.\d+')
+    cd_generated_version = re.compile('v?\d+\.\d+\.\d+\.\d+')
     for tag in tag_list:
-        if minor_version.match(tag):
+        if cd_generated_version.match(tag):
             if display_num <= 0:
                 continue
             filtered_tags.append(tag)
             display_num = display_num - 1
-        elif major_version.match(tag):
+        elif ga_release_version.match(tag):
             filtered_tags.append(tag)
     return filtered_tags
 

--- a/kubos/utils/git_utils.py
+++ b/kubos/utils/git_utils.py
@@ -32,7 +32,7 @@ def get_tag_list(repo):
     tags = repo.tags
     tag_list = []
     for tag in tags:
-        tag_list.append(tag.name)
+        tag_list.insert(0, tag.name)
     return tag_list
 
 

--- a/kubos/utils/git_utils.py
+++ b/kubos/utils/git_utils.py
@@ -63,7 +63,7 @@ def filter_cd_generated_tags(display_num, tag_list):
 def print_tag_list(tag_list, filter=True):
     active_version = get_active_kubos_version()
 
-    if filter:  #filter the CD Gernerated versions
+    if filter:  #filter the CD Generated versions
         tag_list = filter_cd_generated_tags(SHOW_NUMBER_CD_VERSIONS, tag_list)
 
     for tag in tag_list:

--- a/kubos/utils/git_utils.py
+++ b/kubos/utils/git_utils.py
@@ -36,9 +36,10 @@ def get_tag_list(repo):
     return tag_list
 
 
-def filter_minor_tags(display_num, tag_list):
+def filter_cd_generated_tags(display_num, tag_list):
     '''
-    With every merge to Master of the Kubos repo theres a new tag/release generated.
+    With every merge to Master of the Kubos repo theres the CD config generates
+    and releases a new tag/release..
     This filters only the most recent display_num number of release tags.
     '''
     filtered_tags = []
@@ -59,7 +60,7 @@ def print_tag_list(tag_list, filter=True):
     active_version = get_active_kubos_version()
 
     if filter:  #filter the minor versions
-        tag_list = filter_minor_tags(SHOW_NUMBER_MINOR_VERSIONS, tag_list)
+        tag_list = filter_cd_generated_tags(SHOW_NUMBER_MINOR_VERSIONS, tag_list)
 
     for tag in tag_list:
         if tag == active_version:

--- a/kubos/version.py
+++ b/kubos/version.py
@@ -38,7 +38,7 @@ def execCommand(args, following_args):
             version_list = git_utils.get_tag_list(repo)
             logging.info('There\'s not an active Kubos source version..')
             logging.info('The available versions are:')
-            git_utils.print_tag_list(version_list)
+            git_utils.print_tag_list(version_list, filter=True)
             logging.info('Please run kubos use <version> (with one of the above versions)' + \
                   'to checkout a version of the source before working with a project.')
         else:

--- a/kubos/versions.py
+++ b/kubos/versions.py
@@ -24,7 +24,7 @@ from kubos.utils import git_utils
 from kubos.utils.constants import *
 
 def addOptions(parser):
-    parser.add_argument('-a', '--all-versions', action='store_false', default=True, help='Show all available minor versions')
+    parser.add_argument('-a', '--all-versions', dest='filter', action='store_false', default=True, help='Show all available versions')
 
 
 def execCommand(args, following_args):
@@ -35,6 +35,6 @@ def execCommand(args, following_args):
     tag_list = git_utils.get_tag_list(repo)
     latest   = git_utils.get_latest_tag(tag_list)
     logging.info('Available versions are:')
-    git_utils.print_tag_list(tag_list, filter=args.all_versions)
+    git_utils.print_tag_list(tag_list, filter=args.filter)
     logging.info('The most recent release is: %s' % latest)
 

--- a/kubos/versions.py
+++ b/kubos/versions.py
@@ -24,7 +24,7 @@ from kubos.utils import git_utils
 from kubos.utils.constants import *
 
 def addOptions(parser):
-    pass
+    parser.add_argument('-a', '--all-versions', action='store_false', default=True, help='Show all available minor versions')
 
 
 def execCommand(args, following_args):
@@ -35,6 +35,6 @@ def execCommand(args, following_args):
     tag_list = git_utils.get_tag_list(repo)
     latest   = git_utils.get_latest_tag(tag_list)
     logging.info('Available versions are:')
-    git_utils.print_tag_list(tag_list)
+    git_utils.print_tag_list(tag_list, filter=args.all_versions)
     logging.info('The most recent release is: %s' % latest)
 


### PR DESCRIPTION
Adding a filter function to limit the number of minor tags displayed when printing all tags.

The Kubos repo CD process with no be tagging/releasing on every merge to master there will be lots of noise in the `kubos version` command. 

This pr filters out all but the most 3 recent minor tags and shows all major tags without any modification. The `versions` command has a `--all-versions` option to still print all minor versions.