### PR TITLE
KUBOS-399 Adding a function to remove the cmocka dependency when creating RT projects

### DIFF
--- a/kubos/init.py
+++ b/kubos/init.py
@@ -60,7 +60,7 @@ def execCommand(args, following_args):
         final_module_json.write(str_module_data)
     os.chdir(proj_name_dir)
     sdk_utils.link_global_cache_to_project(proj_name_dir)
-    if args.rt:
+    if hasattr(args, 'rt') and args.rt:
         remove_unruly_rt_dependencies()
 
 

--- a/kubos/init.py
+++ b/kubos/init.py
@@ -60,6 +60,24 @@ def execCommand(args, following_args):
         final_module_json.write(str_module_data)
     os.chdir(proj_name_dir)
     sdk_utils.link_global_cache_to_project(proj_name_dir)
+    if args.rt:
+        remove_unruly_rt_dependencies()
+
+
+def remove_unruly_rt_dependencies():
+    '''
+    All modules from the global cache are linked to project during the initialization.
+    For RT projects some dependencies are built even though they are not used and cause errors.
+    This function holds a list of these modules and removes them when RT projects
+    are initialized.
+    '''
+
+    dependency_list = ['cmocka'] #add new module names to the list if new build issues are found in the future.
+
+    for dep in dependency_list:
+        path = os.path.join(os.getcwd(), 'yotta_modules', dep)
+        if os.path.islink(path):
+            os.unlink(path)
 
 def get_target_list():
     '''

--- a/kubos/test/test_sdk_utils.py
+++ b/kubos/test/test_sdk_utils.py
@@ -99,7 +99,7 @@ class KubosSdkUtilsTest(KubosTestCase):
         idx = 0
         for call in call_list:
             args, kwargs = call[0]
-            self.assertEqual(expected_args[idx], args)
+            self.assertTrue(args in expected_args)
             idx = idx + 1
 
 


### PR DESCRIPTION
This is a band-aid type fix for the RT build issue that occurs specifically with the MSP430 target trying to build the cmocka module (Which shouldn't be built by that target). 

When projects are created every target and module is linked into the project (Linux modules are linked into RT projects and vice versa) but theoretically the un-needed modules should not be built. There's a deeper issue that is most likely causing this but will take time to investigate. This isn't the ideal solution but fixes the build issue today.