### PR TITLE
KUBOS-473 GitHub continuous delivery config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,9 @@ test:
         - python ./kubos/test/integration/integration_test.py
         - python setup.py test
 
+
+deployment:
+    production:
+        branch: master
+        commands:
+          - python deploy/deploy.py

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -1,0 +1,114 @@
+# Kubos CLI
+# Copyright (C) 2017 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import release
+import subprocess
+
+this_dir = os.path.dirname(os.path.abspath(__file__))
+cli_root_dir = os.path.dirname(this_dir)
+module_json = os.path.join(cli_root_dir, 'module.json')
+
+def main():
+    '''
+    This script updates versions and builds new versions of the Kubos CLI.
+
+    How to use this script:
+
+    To explicitly set the version of the new release, update the version to what you
+    want in the module.json file. Commit and push the version update change to master. Once
+    the tests pass this script will tag the repo at that new version number (that you set
+    in module.json), and release the module build on github.
+
+    If you don't care about the version number, just merge your changes to master
+    of the kubos-cli repo. Once the tests pass, this will bump the version number
+    and upload the module build to a github release.
+    '''
+    latest_tag = get_latest_tag()
+    module_version = get_module_version()
+    if latest_tag == module_version:
+        version = bump_and_write_version(module_version)
+        commit_and_push(version)
+    else:
+        version = module_version
+
+    build_wheel()
+    release.github_release(version)
+
+
+def get_latest_tag():
+    tag_str = subprocess.check_output(['git', 'tag', '--sort=-creatordate'])
+    tag_list = tag_str.split('\n')
+    latest = tag_list[0]
+    print 'The lastest tag is: %s' % latest
+    return latest
+
+
+def get_module_version():
+    with open(module_json, 'r') as module_file:
+        data = json.loads(module_file.read())
+    version = data['version']
+    print 'The module.json version is: %s' % version
+    return version
+
+
+def bump_and_write_version(version):
+    version_fields = version.split('.')
+
+    if len(version_fields) == 4:  #Add a patch number
+        version_fields[3] = str(int(version_fields[3]) + 1) #bump the version number by 1 and store it as a string
+        version = '.'.join(version_fields)
+    elif len(version_fields) == 3:# bump the version number
+        version = version + '.1'
+
+    with open(module_json, 'r') as module_file:
+        data = json.loads(module_file.read())
+
+    data['version'] = version
+
+    with open(module_json, 'w') as module_file:
+        module_file.write(json.dumps(data,
+                                     sort_keys=True,
+                                     indent=4,
+                                     separators=(',', ': '))
+                                     )
+    return version
+
+
+def commit_and_push(version_number):
+    run_cmd('git', 'add', 'module.json')
+    print 'Committing the version update...'
+    run_cmd('git', 'commit', '-m', '"Bump version to %s. ci skip"' % version_number) #we want ci to skip to prevent an infinite release cycle.
+
+    print 'Pushing the commit to origin...'
+    run_cmd('git', 'push', 'origin', 'master') #push the commit
+
+
+def build_wheel():
+    print 'Building the wheel...'
+    run_cmd('python', 'setup.py', 'bdist_wheel', '--universal')
+
+
+def run_cmd(*args, **kwargs):
+    try:
+        return subprocess.check_output(args, **kwargs)
+    except subprocess.CalledProcessError, e:
+        print >>sys.stderr, 'Error executing command, giving up.\nError Message: %s' % e
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -24,7 +24,7 @@ module_json = os.path.join(cli_root_dir, 'module.json')
 
 def main():
     '''
-    This script updates versions and builds new versions of the Kubos CLI.
+    This script updates, versions, and builds new versions of the Kubos CLI.
 
     How to use this script:
 

--- a/deploy/release.py
+++ b/deploy/release.py
@@ -1,0 +1,96 @@
+# Kubos CLI
+# Copyright (C) 2017 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+This script is a REST API client for creating github releases for the kubos-cli
+repo
+'''
+
+import json
+import os
+import requests
+import sys
+
+from uritemplate import URITemplate, expand
+
+release_endpoint = 'https://api.github.com/repos/kubostech/kubos-cli/releases'
+
+try:
+    token = os.environ['GITHUB_TOKEN']
+except KeyError:
+    print 'Error the environment variable "GITHUB_TOKEN" is not set. Aborting..'
+    sys.exit(1)
+
+auth = ('username', token)
+
+
+def create_release(version):
+    '''
+    Create a new tag/release in the kubos-cli repo
+
+    This function returns the URI template for uploading a release asset
+    '''
+    headers = {
+                'Content-type': 'application/json',
+                'Accept': 'application/json'
+              }
+
+    data    = {
+                'tag_name': version,
+                'target_commitish': 'master',
+                'name': version,
+                'body': '',
+                'draft': False,
+                'prerelease': False
+              }
+
+    res = requests.post(release_endpoint, auth=auth, headers=headers, data=json.dumps(data))
+    res.raise_for_status()
+    return res.json()['upload_url']
+
+
+def upload_wheel(version, uri_template):
+    '''
+    upload the module wheel as a release asset
+    '''
+    print 'Uploading the wheel build...'
+    headers = {
+                'Content-type': 'application/octet-stream',
+                'Accept': 'application/json'
+              }
+
+    template = URITemplate(uri_template)
+    wheel_path = get_wheel_file_path()
+    wheel_file = os.path.basename(wheel_path)
+    url = template.expand(name=wheel_file, label=wheel_file)
+    files = {'files': open(wheel_path, 'rb')}
+    res = requests.post(url, auth=auth, files=files)
+
+
+def get_wheel_file_path():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    dist_dir = os.path.join(this_dir, '..', 'dist')
+    if os.path.isdir(dist_dir):
+        for _file in os.listdir(dist_dir):
+            if _file.endswith('.whl'): #Running in a CD environment, there will only be a single wheel build in the dist/ folder
+                return os.path.join(dist_dir, _file)
+    print 'Unable to find the wheel build under directory %s.. Aborting.' % dist_dir
+    sys.exit(1)
+
+
+def github_release(version):
+    uri_template = create_release(version)
+    upload_wheel(version, uri_template)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ packaging
 pager
 requests
 yotta
+uritemplate==3.0.0
 pysocks


### PR DESCRIPTION
This is similar to #26  but deploys the builds as github releases instead of uploading them to pypi.