### PR TITLE
KUBOS-384 Adding self update functionality to the kubos-cli

### DIFF
--- a/kubos/update.py
+++ b/kubos/update.py
@@ -54,10 +54,10 @@ def update_cli():
     logging.info("updating the Kubos CLI...")
     return_code = subprocess.check_call(INSTALL_COMMAND)
     if return_code == 0:
-        logging.info('Succesfully updated the Kubos-cli module')
+        logging.info('Succesfully updated the Kubos CLI module')
     else:
         #The subprocess stdout/stderr is printed to the console. Any errors that occurr will be visible there.
-        logging.error('There was an issue updating the Kubos-cli module. See the above log for the error details.')
+        logging.error('There was an issue updating the Kubos CLI module. See the above log for the error details.')
 
 
 def update_source_modules(args):

--- a/kubos/update.py
+++ b/kubos/update.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import logging
 import sys
+import subprocess
 import time
 import os
 
@@ -27,12 +28,39 @@ from kubos.utils import git_utils, \
                         status_spinner
 from kubos.utils.constants import *
 
+KUBOS_CLI_REPO_URL = 'git+https://github.com/kubostech/kubos-cli'
+INSTALL_COMMAND    = ['sudo', 'pip', 'install', '--upgrade', KUBOS_CLI_REPO_URL]
+
 def addOptions(parser):
     parser.add_argument('set_version', nargs='?', default=None, help='Specify a version of the kubos source to use.')
     parser.add_argument('-l', '--latest', action='store_true', default=False, help='Default to the most recent release of Kubos modules')
 
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-s', '--source',  dest='component', action='store_const', const='s', default=False, help='Update only the source Kubos modules')
+    group.add_argument('-c', '--cli',     dest='component', action='store_const', const='c', default=False, help='Update the Kubos CLI.')
+    group.add_argument('-a', '--all',     dest='component', action='store_const', const='a', default=False, help='Update both the Kubos source modules and the Kubos CLI')
+    #The default behavior is to only update the source modules.
+    parser.set_defaults(component='s')
+
 
 def execCommand(args, following_args):
+    if args.component == 'a' or args.component == 's':
+        update_source_modules(args)
+    if args.component == 'a' or args.component == 'c':
+        update_cli()
+
+
+def update_cli():
+    logging.info("updating the Kubos-cli...")
+    return_code = subprocess.check_call(INSTALL_COMMAND)
+    if return_code == 0:
+        logging.info('Succesfully updated the Kubos-cli module')
+    else:
+        #The subprocess stdout/stderr is printed to the console. Any errors that occurr will be visible there.
+        logging.error('There was an issue updating the Kubos-cli module. See the above log for the error details.')
+
+
+def update_source_modules(args):
     if not os.path.isdir(KUBOS_DIR):
         os.makedirs(KUBOS_DIR)
     os.chdir(KUBOS_DIR)
@@ -50,3 +78,4 @@ def execCommand(args, following_args):
         latest_tag = git_utils.get_latest_tag(git_utils.get_tag_list(src_repo))
         logging.info('Setting latest release: %s' % latest_tag)
         git_utils.check_provided_version(latest_tag.name, src_repo)
+

--- a/kubos/update.py
+++ b/kubos/update.py
@@ -51,7 +51,7 @@ def execCommand(args, following_args):
 
 
 def update_cli():
-    logging.info("updating the Kubos-cli...")
+    logging.info("updating the Kubos CLI...")
     return_code = subprocess.check_call(INSTALL_COMMAND)
     if return_code == 0:
         logging.info('Succesfully updated the Kubos-cli module')


### PR DESCRIPTION
Updating the module itself from a subprocess shouldn't cause any issues as long as the existing .pyc files are not tampered with (ie. don't delete the /usr/lib/.../kubos directory or start importing new things from kubos after the update subprocess returns)

If running this from outside the vagrant environment stdin should be forwarded from the shell if sudo prompts for a password (tested on my machine). The vagrant environment has a password-less sudo config so this should never be an issue.