### PR TITLE
KUBOS-406 Prevent setting "high level" targets

### DIFF
--- a/kubos/main.py
+++ b/kubos/main.py
@@ -3,6 +3,7 @@
 # Licensed under the Apache License, Version 2.0
 # See LICENSE file for details.
 
+# PYTHON_ARGCOMPLETE_OK
 
 # NOTE: argcomplete must be first!
 import argcomplete

--- a/kubos/main.py
+++ b/kubos/main.py
@@ -3,8 +3,6 @@
 # Licensed under the Apache License, Version 2.0
 # See LICENSE file for details.
 
-# PYTHON_ARGCOMPLETE_OK
-
 # NOTE: argcomplete must be first!
 import argcomplete
 

--- a/kubos/target.py
+++ b/kubos/target.py
@@ -28,7 +28,7 @@ from kubos.utils.sdk_utils import *
 def addOptions(parser):
     proj_type = get_project_type()
     choices = load_target_list(proj_type)
-    parser.add_argument('set_target', nargs='?', default=None, choices=choices, help='set a new target board or display the current target')
+    parser.add_argument('set_target', nargs='?', default=None, choices=choices, help='Set a new target board or display the current target')
     parser.add_argument('-l', '--list', action='store_true', default=False, help='List all of the available target names')
 
 
@@ -77,7 +77,8 @@ def set_target(new_target):
             sys.exit(1)
 
 def print_target_list():
-    target_list = get_target_list()
+    proj_type = get_project_type()
+    target_list = load_target_list(proj_type)
     logging.info('Available targets are:\n')
     for _target in target_list:
         logging.info(_target)

--- a/kubos/target.py
+++ b/kubos/target.py
@@ -26,8 +26,11 @@ from kubos.utils.constants import GLOBAL_TARGET_PATH
 from kubos.utils.sdk_utils import *
 
 def addOptions(parser):
-    parser.add_argument('set_target', nargs='?', default=None, help='set a new target board or display the current target')
+    proj_type = get_project_type()
+    choices = load_target_list(platform=proj_type)
+    parser.add_argument('set_target', nargs='?', default=None, choices=choices, help='set a new target board or display the current target')
     parser.add_argument('-l', '--list', action='store_true', default=False, help='List all of the available target names')
+
 
 def execCommand(args, following_args):
     args = vars(args)

--- a/kubos/target.py
+++ b/kubos/target.py
@@ -27,7 +27,7 @@ from kubos.utils.sdk_utils import *
 
 def addOptions(parser):
     proj_type = get_project_type()
-    choices = load_target_list(platform=proj_type)
+    choices = load_target_list(proj_type)
     parser.add_argument('set_target', nargs='?', default=None, choices=choices, help='set a new target board or display the current target')
     parser.add_argument('-l', '--list', action='store_true', default=False, help='List all of the available target names')
 

--- a/kubos/test/test_sdk_utils.py
+++ b/kubos/test/test_sdk_utils.py
@@ -116,7 +116,7 @@ class KubosSdkUtilsTest(KubosTestCase):
         |_target_b
           |_target_c
 
-        target_c should be the only target that is an elibible target
+        target_c should be the only target that is an eligible target
         '''
 
         inherit_json = '{"name" : "%s", "inherits" : {"%s" : "Fake repo url"}}'

--- a/kubos/update.py
+++ b/kubos/update.py
@@ -49,4 +49,4 @@ def execCommand(args, following_args):
     if args.latest:
         latest_tag = git_utils.get_latest_tag(git_utils.get_tag_list(src_repo))
         logging.info('Setting latest release: %s' % latest_tag)
-        git_utils.check_provided_version(latest_tag.name, src_repo)
+        git_utils.check_provided_version(latest_tag, src_repo)

--- a/kubos/utils/constants.py
+++ b/kubos/utils/constants.py
@@ -28,10 +28,14 @@ KUBOS_LINUX_EXAMPLE_DIR = os.path.join(KUBOS_DIR, 'linux-example')
 
 KUBOS_GIT_DIR = os.path.join(KUBOS_SRC_DIR, '.git')
 KUBOS_VERSION_FILE = os.path.join(KUBOS_DIR, 'version.txt')
+KUBOS_TARGET_CACHE_FILE = os.path.join(KUBOS_DIR, 'targets.json')
 
 KUBOS_RESOURCE_DIR = os.path.join(resource_filename(__name__, ''), '..')
 SDK_MODULE_JSON = os.path.join(KUBOS_RESOURCE_DIR, 'module.json')
 GLOBAL_TARGET_PATH  = os.path.join('/', 'usr', 'local', 'lib', 'yotta_targets')
 GLOBAL_MODULE_PATH  = os.path.join('/', 'usr', 'local', 'lib', 'yotta_modules')
+
+LINUX_KEY = 'linux-targets'
+RT_KEY    = 'rt-targets'
 
 SHOW_NUMBER_CD_VERSIONS = 0

--- a/kubos/utils/sdk_utils.py
+++ b/kubos/utils/sdk_utils.py
@@ -209,21 +209,26 @@ def load_target_list(platform):
 def get_project_type():
     '''
     Returns the project "platform" type: either None, 'linux', or 'rt'
+    This infers the project type from its dependencies. Kubos-rt is the
+    key dependency that differentiates linux and rt projects.
+
+    A return value of None will not limit or filter any target types
     '''
-    platform_key = 'platform'
+    dependency_key = 'dependencies'
     valid_platforms = ['rt', 'linux']
     module_json = os.path.join(os.getcwd(), 'module.json')
     if os.path.isfile(module_json):
         with open(module_json, 'r') as module_file:
             data = json.loads(module_file.read())
-        if platform_key in data:
-            platform = data[platform_key]
-            if platform in valid_platforms:
-                return platform
+        if dependency_key in data:
+            deps = data[dependency_key]
+            if 'kubos-rt' in deps:
+                return 'rt'
             else:
-                logging.warning('Project has an invalid platform type of: %s' % platform)
-                return None
+                return 'linux'
+        else:
+            #This project doesn't have a dependencies field. This is most likely running in a unit testing context
+            return None
     else:
         #There is no module.json
-        logging.info('there no module.json file....')
         return None

--- a/kubos/utils/sdk_utils.py
+++ b/kubos/utils/sdk_utils.py
@@ -191,14 +191,14 @@ def refresh_target_cache():
         target_file.write(json.dumps(data))
 
 
-def load_target_list(platform='all'):
+def load_target_list(platform):
     if not os.path.isdir(KUBOS_TARGET_CACHE_FILE):
         refresh_target_cache()
     with open(KUBOS_TARGET_CACHE_FILE, 'r') as json_file:
         data = json.loads(json_file.read())
     linux_targets = data[LINUX_KEY]
     rt_targets    = data[RT_KEY]
-    if platform == 'all':
+    if platform == None: #if no platform is listed in the module.json, dont restrict the target type
         return linux_targets + rt_targets
     elif platform == 'linux':
         return linux_targets


### PR DESCRIPTION
This also filters the available targets to a project based on its platform type. This pr adds a "platform" attribute to a project's module.json. The key has either an rt or linux value. Depending on the platform type it will only allow the corresponding target types to be set.

This includes a 1 line fix for a bug hanging around from #21 that was causing the integration test to fail. 