### PR TITLE
KUBOS-487 [WIP] Add Tab completion for the `target` command

### DIFF
--- a/kubos/main.py
+++ b/kubos/main.py
@@ -43,6 +43,7 @@ def main():
     # globalconf, share global arguments between modules, internal
     import yotta.lib.globalconf as globalconf
     import yotta.options as options
+    import kubos.options as kubos_options
     # logging setup, , setup the logging system, internal
     from yotta.lib import logging_setup
 
@@ -50,7 +51,7 @@ def main():
 
     # we override many argparse things to make options more re-usable across
     # subcommands, and allow lazy loading of subcommand modules:
-    parser = options.parser.ArgumentParser(
+    parser = kubos_options.parser.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
         description='Kubos-CLI For working with Kubos Projects.\n'+
         'For more detailed help on each subcommand, run: kubos <subcommand> --help'
@@ -70,6 +71,8 @@ def main():
     local_config = sdk_config.load_config()
     add_kubos_command = functools.partial(kubos_options.command.add_command, local_config, subparser, 'kubos') #add our own implemented commands
     add_yotta_command = functools.partial(kubos_options.command.add_command, local_config, subparser, 'yotta') #add from the default yotta commands
+    add_kubos_command_sync = functools.partial(kubos_options.command.add_command_sync, local_config, subparser, 'kubos') #add our own implemented commands
+    add_kubos_command_sync('target', 'target', 'Set or display the current target.')
     add_kubos_command('init', 'init', 'Create a new module.')
     add_yotta_command('build', 'build',
         'Build the current module. Options can be passed to the underlying '+
@@ -101,7 +104,6 @@ def main():
         'Symlink a target'
     )
     add_kubos_command('update', 'update', 'Download newer versions of the KubOS Modules')
-    add_kubos_command('target', 'target', 'Set or display the target device.')
     add_yotta_command('debug', 'debug', 'Attach a debugger to the current target.  Requires target support.')
     add_yotta_command('test', 'test_subcommand',
         'Run the tests for the current module on the current target. A build '+

--- a/kubos/options/__init__.py
+++ b/kubos/options/__init__.py
@@ -1,1 +1,1 @@
-from . import command
+from . import command, parser

--- a/kubos/options/command.py
+++ b/kubos/options/command.py
@@ -17,6 +17,13 @@ class SDKCommand(object):
             formatter_class=argparse.RawTextHelpFormatter,
             callback=self.onParserAdded)
 
+    def addToSubparserSync(self, subparser):
+        subparser.add_parser_sync(
+            self.name, description=self.description, help=self.help,
+            formatter_class=argparse.RawTextHelpFormatter,
+            add_options=self.onParserAdded)
+
+
     def execCommand(self, args, following_args):
         return self.module.execCommand(args, following_args)
 
@@ -29,5 +36,13 @@ class SDKCommand(object):
 def add_command(config, subparser, *args, **kwargs):
     m = _command_class(config, *args, **kwargs)
     m.addToSubparser(subparser)
+
+def add_command_sync(config, subparser, *args, **kwargs):
+    '''
+    For argcomplete to work correctly with the target names we have to synchronously
+    load the target command and its options.
+    '''
+    m = _command_class(config, *args, **kwargs)
+    m.addToSubparserSync(subparser)
 
 _command_class = SDKCommand

--- a/kubos/options/parser.py
+++ b/kubos/options/parser.py
@@ -1,0 +1,68 @@
+# Copyright 2014-2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0
+# See LICENSE file for details.
+
+# standard library modules, , ,
+import argparse
+import copy
+
+# (instead of subclassing argparse._SubParsersAction, we monkey-patch it,
+#  because argcomplete has special-cases for the _SubParsersAction class that
+#  it's impossible to extend to another class)
+#
+# add a add_parser_async function, which allows a subparser to be added whose
+# options are not evaluated until the subparser has been selected. This allows
+# us to defer loading the modules for all the subcommands until they are
+# actually:
+def _SubParsersAction_addParserAsync(self, name, *args, **kwargs):
+    if not 'callback' in kwargs:
+        raise ValueError('callback=fn(parser) argument must be specified')
+    callback = kwargs['callback']
+    del kwargs['callback']
+    parser = self.add_parser(name, *args, **kwargs)
+    import pdb;pdb.set_trace()
+    parser._lazy_load_callback = callback
+    return None
+argparse._SubParsersAction.add_parser_async = _SubParsersAction_addParserAsync
+
+
+def _SubParsersAction_addParserSync(self, name, *args, **kwargs):
+    if not 'add_options' in kwargs:
+        raise ValueError('add_options=fn(parser) argument must be specified')
+    add_options = kwargs['add_options']
+    del kwargs['add_options']
+    parser = self.add_parser(name, *args, **kwargs)
+    add_options(parser)
+    return None
+argparse._SubParsersAction.add_parser_sync = _SubParsersAction_addParserSync
+
+
+def _wrapSubParserActionCall(orig_call):
+    def wrapped_call(self, parser, namespace, values, option_string=None):
+        parser_name = values[0]
+        if parser_name in self._name_parser_map:
+            subparser = self._name_parser_map[parser_name]
+            if hasattr(subparser, '_lazy_load_callback'):
+                # the callback is responsible for adding the subparser's own
+                # arguments:
+                subparser._lazy_load_callback(subparser)
+        # now we can go ahead and call the subparser action: its arguments are
+        # now all set up
+        original_values = copy.copy(vars(namespace))
+        ret = orig_call(self, parser, namespace, values, option_string)
+        # replace any argument value that was clobbered by a "None" value with
+        # its value from the root parser. (the subparser re-sets the default
+        # values for options with are re-used between the root and sub-parsers)
+        for k, v in original_values.items():
+            if v is not None and hasattr(namespace, k):
+                if getattr(namespace, k) is None:
+                    setattr(namespace, k, v)
+        return ret
+    return wrapped_call
+argparse._SubParsersAction.__call__ = _wrapSubParserActionCall(argparse._SubParsersAction.__call__)
+
+# we don't actually modify the parser itself (actually its impossible to do the
+# above modifications by subclassing :()
+ArgumentParser = argparse.ArgumentParser
+

--- a/kubos/target.py
+++ b/kubos/target.py
@@ -25,10 +25,16 @@ from yotta.options import parser
 from kubos.utils.constants import GLOBAL_TARGET_PATH
 from kubos.utils.sdk_utils import *
 
+def target_completer(prefix, parsed_args, **kwargs):
+    proj_type = get_project_type()
+    choices = load_target_list(proj_type)
+    return (c for c in choices if c.startswith(prefix))
+
+
 def addOptions(parser):
     proj_type = get_project_type()
     choices = load_target_list(proj_type)
-    parser.add_argument('set_target', nargs='?', default=None, choices=choices, help='set a new target board or display the current target')
+    parser.add_argument('set_target', nargs='?', choices=choices, default=None, help='set a new target board or display the current target').completer = target_completer
     parser.add_argument('-l', '--list', action='store_true', default=False, help='List all of the available target names')
 
 


### PR DESCRIPTION
The key to this is adding the `target` command definition synchronously so argcomplete can actually know what the available options are. 

This should be generic enough so any future commands that have a set series of option values can be added by simply changing them to be synchronously added. This could be useful if we wanted to add the available module names to the `link` command. 