### PR TITLE
Adding brackets in commit message to get ci to skip the build for a bumped version

### DIFF
--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -93,7 +93,7 @@ def commit_and_push(version_number):
     run_cmd('git', 'config', '--global', 'user.email', os.environ['GITHUB_EMAIL'])
     run_cmd('git', 'add', 'module.json')
     print 'Committing the version update...'
-    run_cmd('git', 'commit', '-m', '"Bump version to %s. ci skip"' % version_number) #we want ci to skip to prevent an infinite release cycle.
+    run_cmd('git', 'commit', '-m', '"Bump version to %s. [ci skip]"' % version_number) #we want ci to skip to prevent an infinite release cycle.
 
     print 'Pushing the commit to origin...'
     run_cmd('git', 'push', 'origin', 'master') #push the commit


### PR DESCRIPTION
Without ci skipping a push to master for the bumped version in module.json it would invoke an infinite cycle of testing and releasing. 

Per the circle CI docs which i misread at first the brackets are needed around "ci skip" in the commit message.

https://circleci.com/docs/1.0/skip-a-build/