### PR TITLE
Unifying the rt dependency removal logic in init and linking.

### DIFF
--- a/kubos/init.py
+++ b/kubos/init.py
@@ -60,7 +60,10 @@ def execCommand(args, following_args):
         final_module_json.write(str_module_data)
     os.chdir(proj_name_dir)
     sdk_utils.link_global_cache_to_project(proj_name_dir)
-    if hasattr(args, 'rt') and args.rt:
+
+    #remove the troublesome rt dependencies if needed
+    proj_type = sdk_utils.get_project_type()
+    if proj_type == 'rt':
         remove_unruly_rt_dependencies()
 
 

--- a/kubos/link.py
+++ b/kubos/link.py
@@ -17,6 +17,7 @@ from yotta import link
 from yotta.options import parser
 
 from kubos.utils.sdk_utils import *
+from kubos.init import remove_unruly_rt_dependencies
 
 def addOptions(parser):
     parser.add_argument('-a', '--all', action='store_true', default=False,
@@ -43,6 +44,9 @@ def execCommand(args, following_args):
     arg_dict = vars(args)
     if arg_dict['all']:
         link_global_cache_to_project(os.getcwd())
+        proj_type = get_project_type()
+        if proj_type == 'rt':
+            remove_unruly_rt_dependencies()
     else:
         #pass in the args argparse.Namespace object - not the dictionary from above
         link.execCommand(args, following_args)

--- a/kubos/test/test_init.py
+++ b/kubos/test/test_init.py
@@ -22,6 +22,7 @@ import unittest
 from kubos import init
 from kubos.test import utils
 from kubos.utils import constants
+from mock import patch
 from yotta.test.cli.test_target import Test_Module_JSON #A dummy module.json config
 
 class KubosInitTest(utils.KubosTestCase):
@@ -60,6 +61,17 @@ class KubosInitTest(utils.KubosTestCase):
         kubos.init.execCommand(self.args, None)
         self.assertTrue(os.path.isdir(self.proj_dir))
 
+    @patch('kubos.init.remove_unruly_rt_dependencies')
+    def test_rt_init_removes_rt_toublesome_dependencies(self, remove_deps):
+        # self.args already contains linux=False
+        kubos.init.execCommand(self.args, None)
+        remove_deps.assert_called_once()
+
+    @patch('kubos.init.remove_unruly_rt_dependencies')
+    def test_linux_init_does_not_remove_rt_toublesome_dependencies(self, remove_deps):
+        self.args.linux = True
+        kubos.init.execCommand(self.args, None)
+        remove_deps.assert_not_called()
 
     def test_overwrite_existing(self):
         self.proj_name = 'test-project'


### PR DESCRIPTION
And adding unit tests for these test cases.

This cleans up how we're removing the cmocka dependency from the rt projects, and adds the same logic to the `link --all` command. This allows msp builds of cloned projects to build successfully.